### PR TITLE
Define Undine::Configuratio for users to customize query message from exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Undine
 
+[![Gem Version](https://badge.fury.io/rb/undine.svg)](https://badge.fury.io/rb/undine)
 [![Build Status](https://travis-ci.org/satoryu/undine.svg?branch=master)](https://travis-ci.org/satoryu/undine)
 
 Undine is a gem to help your development experience: When an exception unrescued in your  code is raised, opens google search with the errror message in your browser.

--- a/examples/with_configuration.rb
+++ b/examples/with_configuration.rb
@@ -1,0 +1,12 @@
+require 'undine'
+
+Undine.load
+
+Undine.configure do |config|
+  config.query_message_from = proc { |e| e.message.lines.join(' ') }
+end
+
+'hoge'.foo
+# This statement raises the following exception:
+#   examples/with_configuration.rb:9:in `<main>': undefined method `foo' for "hoge":String (NoMethodError)
+#   Did you mean?  for

--- a/lib/undine.rb
+++ b/lib/undine.rb
@@ -2,11 +2,12 @@
 
 require 'undine/version'
 require 'cgi'
+require 'English'
 
 class Undine
   def self.load
     at_exit do
-      exception = $!
+      exception = $ERROR_INFO
 
       Undine.process(exception) unless exception.nil?
     end

--- a/lib/undine.rb
+++ b/lib/undine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'undine/version'
+require 'undine/configuration'
 require 'cgi'
 require 'English'
 
@@ -14,12 +15,20 @@ class Undine
   end
 
   def self.process(exception)
-    new.process(exception)
+    new(Undine.configuration).process(exception)
+  end
+
+  def initialize(configuration)
+    @configuration = configuration
   end
 
   def process(exception)
-    url = "https://www.google.com/search?q=#{CGI.escape(exception.message)}"
+    url = "https://www.google.com/search?q=#{CGI.escape(query_message_from(exception))}"
 
     system "open '#{url}'"
+  end
+
+  def query_message_from(exception)
+    @configuration.query_message_from.call(exception)
   end
 end

--- a/lib/undine/configuration.rb
+++ b/lib/undine/configuration.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class Undine
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.configure
+    yield configuration
+  end
+
+  class Configuration
+    attr_accessor :query_message_from
+
+    def initialize
+      @query_message_from = :message.to_proc
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Undine::Configuration do
+  describe '.configure' do
+    context 'Given block' do
+      specify 'the block receives a Congiuration object' do
+        expect { |b| Undine.configure(&b) }.to yield_with_args(Undine::Configuration)
+      end
+    end
+  end
+
+  describe '.configuration' do
+    subject { Undine.configuration }
+
+    it { is_expected.to be_a(Undine::Configuration) }
+    it { is_expected.to eq(Undine.configuration) }
+  end
+end

--- a/spec/undine_spec.rb
+++ b/spec/undine_spec.rb
@@ -2,14 +2,23 @@ require 'spec_helper'
 
 RSpec.describe Undine do
   let(:exception) { Exception.new('hoge') }
+  let(:configuration) { double(:config, query_message_from: :message.to_proc ) }
 
   describe '#process' do
-    subject { Undine.new }
+    subject { Undine.new(configuration) }
 
     it 'uses system method to open browser' do
       expect(subject).to receive(:system).with("open 'https://www.google.com/search?q=hoge'")
 
       subject.process(exception)
     end
+  end
+
+  describe '#query_message_from' do
+    let(:exception) { Exception.new('foo') }
+
+    subject { Undine.new(configuration).query_message_from(exception) }
+
+    it { is_expected.to eq(exception.message) }
   end
 end


### PR DESCRIPTION
This PR provides `Undine.configure` and `Undine.configuration` in order for users to customize a query message from exceptions caught by `Undine`. 

## Usage

```ruby
Undine.configure do |c|
  config.query_message_from = proc { |e| e.message.lines.join(' ') }
end
```

In default, `query_message_from` is a proc to call given exception's `message`. 

After this configuration, executing codes which raises unrescued exception makes `Undine` open google:

```ruby
'hoge'.foo
```

This code raises `NoMethodError` with message of two lines:
```
undefined method `foo' for "hoge":String (NoMethodError)
Did you mean?  for
```

Generated url is like this: https://www.google.com/search?q=undefined+method+%60foo%27+for+%22hoge%22%3AString%0A+Did+you+mean%3F++for