### PR TITLE
Define autoload

### DIFF
--- a/lib/undine/autoload.rb
+++ b/lib/undine/autoload.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require 'undine'
+
+Undine.load


### PR DESCRIPTION
This PR provides a file for users to load `Undine.load` automatically without modifying the users' codes.

## Usage

If your app uses bundler,  gives `require: 'undine/autoload'` option to `gem` as follows:

```ruby
gem 'undine', require: 'undine/autoload', groups: :development
```

Or specifies `-r` option to `ruby` command to `require` `undine/autoload`:

```sh
ruby -r'undine/autoload' /path/to/your/ruby/script.rb
```
