### PR TITLE
Configuration allows to specify exception classes to be ignored

### DIFF
--- a/lib/undine.rb
+++ b/lib/undine.rb
@@ -30,11 +30,11 @@ class Undine
     system "open '#{url}'"
   end
 
-  private
-
   def query_message_from(exception)
     @configuration.query_message_from.call(exception)
   end
+
+  private
 
   def ignore?(exception)
     return false unless @configuration.respond_to?(:except_for)

--- a/lib/undine.rb
+++ b/lib/undine.rb
@@ -23,12 +23,23 @@ class Undine
   end
 
   def process(exception)
+    return if ignore?(exception)
+
     url = "https://www.google.com/search?q=#{CGI.escape(query_message_from(exception))}"
 
     system "open '#{url}'"
   end
 
+  private
+
   def query_message_from(exception)
     @configuration.query_message_from.call(exception)
+  end
+
+  def ignore?(exception)
+    return false unless @configuration.respond_to?(:except_for)
+
+    ignored_exceptions = Array(@configuration.except_for)
+    ignored_exceptions.any? { |klass| exception.is_a?(klass) }
   end
 end

--- a/lib/undine/configuration.rb
+++ b/lib/undine/configuration.rb
@@ -11,9 +11,11 @@ class Undine
 
   class Configuration
     attr_accessor :query_message_from
+    attr_accessor :except_for
 
     def initialize
       @query_message_from = :message.to_proc
+      @except_for = SystemExit
     end
   end
 end

--- a/spec/undine_spec.rb
+++ b/spec/undine_spec.rb
@@ -12,6 +12,17 @@ RSpec.describe Undine do
 
       subject.process(exception)
     end
+
+    context 'When except_for is configured' do
+      let(:exception) { SystemExit.new }
+      let(:configuration) { double(:config, except_for: SystemExit) }
+
+      it 'does not open browser' do
+        expect(subject).to_not receive(:system)
+
+        subject.process(exception)
+      end
+    end
   end
 
   describe '#query_message_from' do


### PR DESCRIPTION
For instance, when exiting a command like `rails`, `SystemExit` is raised. Sometimes users think that it should be ignored from targets of `Undine`.

This PR provides updates on `Undine::Configuration` and `Undine#process` to allow developers to specify exceptions to be ignored. 

## Usage

```ruby
Undine.configure do |c|
  c.except_for = [SystemExit, YourExceptionClass]
end
```
